### PR TITLE
Encapsulate artist property in ArtistCellPresenter

### DIFF
--- a/BestPractices.xcodeproj/project.pbxproj
+++ b/BestPractices.xcodeproj/project.pbxproj
@@ -69,6 +69,8 @@
 		AE0D92EC18EF5BE40043F06A /* ArtistCellPresenterSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE0D92EB18EF5BE40043F06A /* ArtistCellPresenterSpec.mm */; };
 		AE0D92FD18EF6B2F0043F06A /* ArtistsPresenterSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE0D92FC18EF6B2F0043F06A /* ArtistsPresenterSpec.mm */; };
 		AE0D930118EF6CB30043F06A /* FakeCellPresenterDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = AE0D930018EF6CB30043F06A /* FakeCellPresenterDataSource.m */; };
+		FAFFB95D1B2CECBF0057D078 /* DomainModule.m in Sources */ = {isa = PBXBuildFile; fileRef = FAFFB95C1B2CECBF0057D078 /* DomainModule.m */; };
+		FAFFB95E1B2CED170057D078 /* DomainModule.m in Sources */ = {isa = PBXBuildFile; fileRef = FAFFB95C1B2CECBF0057D078 /* DomainModule.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -347,6 +349,8 @@
 		AE0D92FC18EF6B2F0043F06A /* ArtistsPresenterSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ArtistsPresenterSpec.mm; sourceTree = "<group>"; };
 		AE0D92FF18EF6CB30043F06A /* FakeCellPresenterDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FakeCellPresenterDataSource.h; sourceTree = "<group>"; };
 		AE0D930018EF6CB30043F06A /* FakeCellPresenterDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FakeCellPresenterDataSource.m; sourceTree = "<group>"; };
+		FAFFB95B1B2CECBF0057D078 /* DomainModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DomainModule.h; sourceTree = "<group>"; };
+		FAFFB95C1B2CECBF0057D078 /* DomainModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DomainModule.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -483,14 +487,16 @@
 			children = (
 				4C8145C018E5173700FA565A /* InjectorKeys.h */,
 				4C8145C118E5173700FA565A /* InjectorKeys.m */,
+				2225F2505B1A22EAFBA465A9 /* InjectorProvider.h */,
+				2225F92CBED5E79032067389 /* InjectorProvider.m */,
 				4C8145BA18E5169700FA565A /* UIModule.h */,
 				4C8145BB18E5169700FA565A /* UIModule.m */,
-				2225FDE9BB696E631352A547 /* NetworkModule.m */,
 				2225F9FEDEF77FFBD57BF6FA /* NetworkModule.h */,
-				2225F92CBED5E79032067389 /* InjectorProvider.m */,
-				2225F2505B1A22EAFBA465A9 /* InjectorProvider.h */,
-				2225F7D69CE3204D81E2C21A /* FoundationModule.m */,
+				2225FDE9BB696E631352A547 /* NetworkModule.m */,
 				2225FFF8E0C1013B1F990D53 /* FoundationModule.h */,
+				2225F7D69CE3204D81E2C21A /* FoundationModule.m */,
+				FAFFB95B1B2CECBF0057D078 /* DomainModule.h */,
+				FAFFB95C1B2CECBF0057D078 /* DomainModule.m */,
 			);
 			path = Modules;
 			sourceTree = "<group>";
@@ -928,6 +934,7 @@
 				4C8145BC18E5169700FA565A /* ArtistsViewController.m in Sources */,
 				4C8145BE18E5169700FA565A /* UIModule.m in Sources */,
 				4C1650DD18E50CA1000336FD /* AppDelegate.m in Sources */,
+				FAFFB95D1B2CECBF0057D078 /* DomainModule.m in Sources */,
 				4CA3C85F18E77BB70082556D /* ArtistsPresenter.m in Sources */,
 				4C1650D918E50CA1000336FD /* main.m in Sources */,
 				4CA3C85B18E77B3B0082556D /* CellPresenterDataSource.m in Sources */,
@@ -964,6 +971,7 @@
 				AE0D92FD18EF6B2F0043F06A /* ArtistsPresenterSpec.mm in Sources */,
 				4CBB0C401AD0715F00F03491 /* ArtistsServiceSpec.mm in Sources */,
 				2225F526C12E802C9A23F066 /* HTTPClient.m in Sources */,
+				FAFFB95E1B2CED170057D078 /* DomainModule.m in Sources */,
 				2225FDE8FD3E7AFB0D28245B /* JSONClient.m in Sources */,
 				2225FE53D11DF6DDDD676231 /* HTTPClientSpec.mm in Sources */,
 				2225FC0F494B4C351C0109D2 /* JSONClientSpec.mm in Sources */,

--- a/BestPractices/Modules/DomainModule.h
+++ b/BestPractices/Modules/DomainModule.h
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+#import "Blindside.h"
+
+@interface DomainModule : NSObject <BSModule>
+
+@end

--- a/BestPractices/Modules/DomainModule.m
+++ b/BestPractices/Modules/DomainModule.m
@@ -1,0 +1,14 @@
+#import "DomainModule.h"
+#import "ArtistCellPresenter.h"
+#import "Artist.h"
+
+@implementation DomainModule
+
+- (void)configure:(id<BSBinder>)binder {
+    [binder bind:[ArtistCellPresenter class] toBlock:^id(NSArray *args, id<BSInjector> injector) {
+        Artist *artist = (Artist *)args.firstObject;
+        return [[ArtistCellPresenter alloc] initWithArtist:artist];
+    }];
+}
+
+@end

--- a/BestPractices/Modules/InjectorProvider.m
+++ b/BestPractices/Modules/InjectorProvider.m
@@ -3,6 +3,7 @@
 #import "FoundationModule.h"
 #import "NetworkModule.h"
 #import "UIModule.h"
+#import "DomainModule.h"
 
 
 @implementation InjectorProvider
@@ -11,7 +12,8 @@
     NSArray *modules = @[
         [[FoundationModule alloc] init],
         [[NetworkModule alloc] init],
-        [[UIModule alloc] init]
+        [[UIModule alloc] init],
+        [[DomainModule alloc] init]
     ];
 
     return [Blindside injectorWithModules:modules];

--- a/BestPractices/Presenters/ArtistCellPresenter.h
+++ b/BestPractices/Presenters/ArtistCellPresenter.h
@@ -7,6 +7,8 @@
 
 @interface ArtistCellPresenter : NSObject <CellPresenter>
 
-@property (nonatomic) Artist *artist;
+@property (nonatomic, readonly) Artist *artist;
+
+- (instancetype)initWithArtist:(Artist *)artist;
 
 @end

--- a/BestPractices/Presenters/ArtistCellPresenter.m
+++ b/BestPractices/Presenters/ArtistCellPresenter.m
@@ -2,10 +2,23 @@
 #import "Artist.h"
 
 
+@interface ArtistCellPresenter ()
+@property (nonatomic, readwrite) Artist *artist;
+@end
+
+
 @implementation ArtistCellPresenter
 
 + (void)registerInTableView:(UITableView *)tableView {
     return [tableView registerClass:[UITableViewCell class] forCellReuseIdentifier:@"ArtistCell"];
+}
+
+- (instancetype)initWithArtist:(Artist *)artist {
+    self = [super init];
+    if (self) {
+        self.artist = artist;
+    }
+    return self;
 }
 
 - (void)presentInCell:(UITableViewCell *)cell {

--- a/BestPractices/Presenters/ArtistsPresenter.m
+++ b/BestPractices/Presenters/ArtistsPresenter.m
@@ -35,9 +35,7 @@
     NSMutableArray *cellPresenters = [NSMutableArray arrayWithCapacity:artists.count];
     
     for (Artist *artist in artists) {
-        ArtistCellPresenter *cellPresenter = [self.injector getInstance:[ArtistCellPresenter class]];
-        cellPresenter.artist = artist;
-        [cellPresenters addObject:cellPresenter];
+        [cellPresenters addObject:[self.injector getInstance:[ArtistCellPresenter class] withArgs:artist, nil]];
     }
     
     [self.cellPresenterDataSource displayCellPresenters:cellPresenters inTableView:tableView];

--- a/BestPracticesSpecs/Presenters/ArtistCellPresenterSpec.mm
+++ b/BestPracticesSpecs/Presenters/ArtistCellPresenterSpec.mm
@@ -19,9 +19,9 @@ describe(@"ArtistCellPresenter", ^{
     beforeEach(^{
         injector = (id)[InjectorProvider injector];
 
-        subject = [injector getInstance:[ArtistCellPresenter class]];
-        
-        subject.artist = [[Artist alloc] initWithId:@"1" name:@"Pink Floyd"];
+        Artist *artist = [[Artist alloc] initWithId:@"1" name:@"Pink Floyd"];
+
+        subject = [injector getInstance:[ArtistCellPresenter class] withArgs:artist, nil];
         
         cell = [[UITableViewCell alloc] init];
         [subject presentInCell:cell];


### PR DESCRIPTION
Addresses Issue #1 by exposing `artist` as a readonly property in `ArtistCellPresenter`. It also creates a new initializer, `- initWithArtist:`, and it creates a `DomainModule` to allow for creation of a new `ArtistCellPresenter` via Blindside.
